### PR TITLE
Awaiting the inner task instead of outer task

### DIFF
--- a/ParkenDD/Controls/ParkingLotForecastChart.xaml.cs
+++ b/ParkenDD/Controls/ParkingLotForecastChart.xaml.cs
@@ -152,7 +152,7 @@ namespace ParkenDD.Controls
                 {
                     ForecastChart.Opacity = 0.2;
                     LoadingProgressRing.Visibility = Visibility.Visible;
-                    await Task.Factory.StartNew(async () =>
+                    await Task.Run(async () =>
                     {
                         var api = ServiceLocator.Current.GetInstance<IParkenDdClient>();
                         var mainVm = ServiceLocator.Current.GetInstance<MainViewModel>();

--- a/ParkenDD/ViewModels/MainViewModel.cs
+++ b/ParkenDD/ViewModels/MainViewModel.cs
@@ -1078,7 +1078,7 @@ namespace ParkenDD.ViewModels
                     _initialized = true;
                 }
 
-                await Task.Factory.StartNew(async () =>
+                await Task.Run(async () =>
                 {
                     do
                     {


### PR DESCRIPTION
Task.Factory.StartNew returns a nested task (Task<Task>). Awaiting a nested task is dangerous so we should always unwrap the nested task (with Unwrap() or using Task.Run) and await the inner task.
